### PR TITLE
Fix Transloco namespace casing

### DIFF
--- a/frontend/src/app/pages/not-found/not-found.html
+++ b/frontend/src/app/pages/not-found/not-found.html
@@ -1,1 +1,1 @@
-<p *transloco="let t">{{ t('not-found.404Works') }}</p>
+<p *transloco="let t">{{ t('notFound.404Works') }}</p>

--- a/frontend/src/app/pages/user-profile/user-profile.html
+++ b/frontend/src/app/pages/user-profile/user-profile.html
@@ -1,1 +1,1 @@
-<p *transloco="let t">{{ t('user-profile.userProfileWorks') }}</p>
+<p *transloco="let t">{{ t('userProfile.userProfileWorks') }}</p>


### PR DESCRIPTION
## Описание изменений
Переключение языков не работало на User Profile и Not found страницах. Проблема связана с тем, как Transloco работает со scope. Страницы в роутинге используют: `provideTranslocoScope('user-profile')`

Из документации: `By default, in Transloco the namespace will be the scope’s name in camelCase`. Поэтому наименования с `-` неправильно высчитывались.

### Решение

Использовать camelCase scope. Пример:

❌ Incorrect: `{{ t('user-profile.userProfileWorks') }}`

✅ Correct: `{{ t('userProfile.userProfileWorks') }}`

<img width="150" src="https://media4.giphy.com/media/v1.Y2lkPWJkM2VhNTdlengyMmUycWlvMngwOXdmeG53dmoyY3BwZnRpcDVxdGtqazIyZmxueCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/Z9zo37ooUzwNwzmw4w/giphy.gif"/>

## Связанная задача (issue)
<!-- Укажите номер задачи, например: Fixes #123, Closes #456 -->
[issue #37](https://github.com/ngKittyDebug/RS-Tandem-ngKittyDebug/issues/37)

## Тип изменений
<!-- Отметьте нужные варианты, убрав пробел в скобках [ ] и поставив x: [x] -->
- [x] 🐛 Исправление бага (неразрушающее изменение, которое исправляет проблему)
- [ ] ✨ Новая функция (неразрушающее изменение, добавляющее функционал)
- [ ] 📚 Обновление документации
- [ ] 🎨 Рефакторинг кода
- [ ] ✅ Добавление/обновление тестов
- [ ] 🔧 Изменения в конфигурации/инфраструктуре


## Скриншоты (если применимо)
<!-- Для UI-изменений добавьте скриншоты "до" и "после" -->
![3-1](https://github.com/user-attachments/assets/bc67ba47-84e7-4cf8-bced-3b88511d3d2a)
![3-2](https://github.com/user-attachments/assets/12696096-f79a-40cd-8b50-13b896da704b)
