### PR TITLE
fix(theme-switcher.spec): fix typo in describe block name

### DIFF
--- a/frontend/src/app/core/components/theme-switcher/theme-switcher.spec.ts
+++ b/frontend/src/app/core/components/theme-switcher/theme-switcher.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ThemeSwitcher } from './theme-switcher';
 import { ThemeService } from '../../services/theme-service';
 
-describe('ThemeSwither', () => {
+describe('ThemeSwitcher', () => {
   let component: ThemeSwitcher;
   let fixture: ComponentFixture<ThemeSwitcher>;
   const themeServiceMock = {


### PR DESCRIPTION
## Summary

- Исправлена опечатка в названии `describe`-блока: `ThemeSwither` → `ThemeSwitcher`

## Changes

- `src/app/core/components/theme-switcher/theme-switcher.spec.ts:6`

## Test plan

- [x] Все тесты проходят (`npm test`)
- [x] Typecheck проходит (`npm run typecheck`)
- [x] Lint проходит (`npm run lint`)

Fixes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)