### PR TITLE
fix(index.html): replace placeholder title with product name MeowVault

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>Frontend</title>
+    <title>MeowVault</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />


### PR DESCRIPTION
## Summary

- Заменён технический placeholder `<title>Frontend</title>` на корректное название продукта `<title>MeowVault</title>` в `src/index.html`

## Test plan

- [x] Тесты проходят (`npm test` — 64 passed)
- [x] Typecheck чистый
- [x] Проверить в браузере, что вкладка отображает «MeowVault»

Fixes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)