### PR TITLE
fix(theme-switcher): checkbox not bound to current theme — missing [checked] binding

### DIFF
--- a/frontend/src/app/core/components/theme-switcher/theme-switcher.html
+++ b/frontend/src/app/core/components/theme-switcher/theme-switcher.html
@@ -2,6 +2,7 @@
   size="s"
   tuiLike
   type="checkbox"
+  [checked]="themeService.theme() === ThemeNames.Light"
   [checkedIcon]="'@tui.moon-filled'"
   [uncheckedIcon]="'@tui.sun-filled'"
   (change)="onChangeTheme()"

--- a/frontend/src/app/core/components/theme-switcher/theme-switcher.spec.ts
+++ b/frontend/src/app/core/components/theme-switcher/theme-switcher.spec.ts
@@ -1,13 +1,16 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { signal } from '@angular/core';
 
 import { ThemeSwitcher } from './theme-switcher';
 import { ThemeService } from '../../services/theme-service';
+import { ThemeNames } from '../../../shared/enums/theme-names.enum';
 
 describe('ThemeSwither', () => {
   let component: ThemeSwitcher;
   let fixture: ComponentFixture<ThemeSwitcher>;
   const themeServiceMock = {
     changeTheme: vi.fn(),
+    theme: signal<string>(ThemeNames.Light),
   };
 
   beforeEach(async () => {
@@ -28,5 +31,23 @@ describe('ThemeSwither', () => {
   it('should toggle theme on switcher change', async () => {
     component.onChangeTheme();
     expect(themeServiceMock.changeTheme).toHaveBeenCalled();
+  });
+
+  it('should render checkbox as checked when light theme is active', async () => {
+    themeServiceMock.theme.set(ThemeNames.Light);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const checkbox = fixture.nativeElement.querySelector('input[type="checkbox"]');
+    expect(checkbox.checked).toBe(true);
+  });
+
+  it('should render checkbox as unchecked when dark theme is active', async () => {
+    themeServiceMock.theme.set(ThemeNames.Dark);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    const checkbox = fixture.nativeElement.querySelector('input[type="checkbox"]');
+    expect(checkbox.checked).toBe(false);
   });
 });

--- a/frontend/src/app/core/components/theme-switcher/theme-switcher.ts
+++ b/frontend/src/app/core/components/theme-switcher/theme-switcher.ts
@@ -2,6 +2,7 @@ import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { TuiLike } from '@taiga-ui/kit';
 import { ThemeService } from '../../services/theme-service';
+import { ThemeNames } from '../../../shared/enums/theme-names.enum';
 
 @Component({
   selector: 'app-theme-switcher',
@@ -13,6 +14,7 @@ import { ThemeService } from '../../services/theme-service';
 })
 export class ThemeSwitcher {
   protected readonly themeService = inject(ThemeService);
+  protected readonly ThemeNames = ThemeNames;
 
   public onChangeTheme(): void {
     this.themeService.changeTheme();


### PR DESCRIPTION
## Summary

- Добавлена привязка `[checked]` к сигналу `themeService.theme()` в компоненте `ThemeSwitcher`
- Добавлен `ThemeNames` enum в компонент для использования в шаблоне
- Добавлены 2 unit-теста проверяющих состояние чекбокса при каждой теме

## Детали бага (визуальное тестирование)

После перезагрузки страницы без привязки `[checked]` чекбокс всегда инициализировался в состоянии `false` (unchecked), что давало неверную иконку при светлой теме:

| Состояние | Тема | `checked` | Иконка | Ожидается |
|---|---|---|---|---|
| После перезагрузки (тёмная) | dark | false | ☀️ | ☀️ ✅ |
| Во время сессии (переключил на светлую) | light | true | 🌙 | 🌙 ✅ |
| **После перезагрузки (светлая)** | light | false | **☀️** | **🌙 ❌** |

Ожидаемое поведение: тёмная тема → иконка ☀️ (переключиться на светлую), светлая тема → иконка 🌙 (переключиться на тёмную). Баг проявлялся только при перезагрузке в светлой теме — иконка показывала солнце вместо луны.

## Исправление

```html
<!-- было -->
<input tuiLike type="checkbox" (change)="onChangeTheme()" />

<!-- стало -->
<input tuiLike type="checkbox" [checked]="themeService.theme() === ThemeNames.Light" (change)="onChangeTheme()" />
```

`[checked]="ThemeNames.Light"` — потому что `checkedIcon` это луна (иконка для переключения в тёмную), а нужна она на светлой теме.

## Test plan

- [x] Все существующие тесты проходят (66 passed)
- [x] Новый тест: checkbox checked при светлой теме
- [x] Новый тест: checkbox unchecked при тёмной теме
- [x] Визуальная проверка в браузере: перезагрузка в обеих темах показывает корректную иконку

Fixes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)