### PR TITLE
fix(app.config): use useFactory for localStorage in translocoPersistLang

### DIFF
--- a/frontend/src/app/app.config.ts
+++ b/frontend/src/app/app.config.ts
@@ -42,7 +42,7 @@ export const appConfig: ApplicationConfig = {
     }),
     provideTranslocoPersistLang({
       storage: {
-        useValue: localStorage,
+        useFactory: () => localStorage,
       },
     }),
     provideAppInitializer(() => {


### PR DESCRIPTION
## Summary

- Заменён `useValue: localStorage` на `useFactory: () => localStorage` в `provideTranslocoPersistLang`, что предотвращает `ReferenceError: localStorage is not defined` при SSR/prerendering

## Test plan

- [x] Переключение языков ru/en работает корректно на `http://localhost:4200/`
- [x] Все 64 unit-теста прошли успешно

Fixes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)