### PR TITLE
fix(app.spec): replace skipped test with valid layout assertion

### DIFF
--- a/frontend/src/app/app.spec.ts
+++ b/frontend/src/app/app.spec.ts
@@ -27,10 +27,10 @@ describe('App', () => {
     expect(app).toBeTruthy();
   });
 
-  it.skip('should render title', async () => {
+  it('should render main layout element', async () => {
     const fixture = TestBed.createComponent(App);
     await fixture.whenStable();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('p')?.textContent).toContain('main works!');
+    expect(compiled.querySelector('main.main')).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Summary

- Убран `it.skip` с некорректным assertion (`'main works!'`)
- Добавлен рабочий тест `should render main layout element`, который проверяет наличие `<main class="main">` в DOM после рендера компонента

## Test plan

- [x] `npm test` — 65/65 тестов проходят

Fixes #124